### PR TITLE
레이아웃&버튼 컴포넌트 수정

### DIFF
--- a/src/duckku-ui/Button/index.jsx
+++ b/src/duckku-ui/Button/index.jsx
@@ -20,6 +20,7 @@ const Button = styled.button`
   z-index: inherit;
   line-height: 29px;
   letter-spacing: 0.55px;
+  cursor: pointer;
 `;
 
 export default withTheme(Button);

--- a/src/duckku-ui/Layout/index.jsx
+++ b/src/duckku-ui/Layout/index.jsx
@@ -3,9 +3,7 @@ import styled from "styled-components";
 import Flex from "../Flex";
 
 const Width = styled.div`
-  height: 100% !important;
-  min-height: 550px;
-  max-height: 844px;
+  min-height: 844px;
   max-width: 390px;
   margin: 0 auto;
   padding-top: 20px;
@@ -14,15 +12,9 @@ const Width = styled.div`
   background-color: white;
 `;
 
-const StyledFlex = styled(Flex)`
-  height: 100% !important;
-`;
-
 const BackColor = styled.div`
   width: 100%;
-  height: 100%;
   background-color: #d3d3d3;
-
   display: flex;
   justify-content: center;
   align-items: center;
@@ -31,9 +23,9 @@ const BackColor = styled.div`
 const Layout = ({ children }) => (
   <BackColor>
     <Width>
-      <StyledFlex align="center" direction="column">
+      <Flex align="center" direction="column">
         {children}
-      </StyledFlex>
+      </Flex>
     </Width>
   </BackColor>
 );


### PR DESCRIPTION

<img width="1903" alt="image" src="https://user-images.githubusercontent.com/34507976/183476312-3cf1086b-58c7-44c0-9662-d2c4e6600312.png">

1. 레이아웃 컴포넌트에 max-height로 인해 넘칠 경우 스크롤이 안되는 문제 수정
2. 버튼 컴포넌트 cursor: pointer 추가