### PR TITLE
메인 홈 페이지 작성

### DIFF
--- a/src/pages/MainHome/components/artistCard.jsx
+++ b/src/pages/MainHome/components/artistCard.jsx
@@ -1,11 +1,19 @@
 import styled, { css } from "styled-components";
 import Button from "../../../duckku-ui/Button";
 import Typography from "../../../duckku-ui/Typography";
+import { HiOutlineChevronRight } from "react-icons/hi";
+
+const Wrapper = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+`;
 
 // 카드 전체 component
 const CardWrapper = styled.div`
   width: 326px;
   height: 484px;
+  margin-bottom: 29px;
   background: url(${(props) => (props.imgLink ? props.imgLink : "")}) no-repeat;
   background-size: cover;
   filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
@@ -27,6 +35,7 @@ const ButtomWrapper = styled.div`
   flex-direction: row;
   align-items: center;
   justify-content: center;
+  vertical-align: middle;
   margin-bottom: 21px;
 `;
 
@@ -63,22 +72,40 @@ const ArtistLogoBox = styled.div`
   vertical-align: middle;
 `;
 
+const Flex = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+  margin-left: 7px;
+`;
+
 // 버튼의 경우 Figma 기준으로 blur와 투명도가 들어갔으나, 해당 option이 없어 미구현
 const ArtistCard = (props) => {
   return (
-    <CardWrapper imgLink={props.imgLink}>
-      <TopWrapper>
-        <ArtistNameBox>
-          <Typography bold16 color="white">
-            RedVelvet
-          </Typography>
-        </ArtistNameBox>
-        <ArtistLogoBox iconLink={props.iconLink} />
-      </TopWrapper>
-      <ButtomWrapper>
-        <Button width="150" height="44"></Button>
-      </ButtomWrapper>
-    </CardWrapper>
+    <Wrapper>
+      <CardWrapper imgLink={props.imgLink}>
+        <TopWrapper>
+          <ArtistNameBox>
+            <Typography bold16 color="white">
+              RedVelvet
+            </Typography>
+          </ArtistNameBox>
+          <ArtistLogoBox iconLink={props.iconLink} />
+        </TopWrapper>
+        <ButtomWrapper>
+          <Button width="150" height="44">
+            <Flex>
+              <Typography bold16 color="white">
+                앨범함 가기
+              </Typography>
+              <HiOutlineChevronRight size="20" />
+            </Flex>
+          </Button>
+        </ButtomWrapper>
+      </CardWrapper>
+    </Wrapper>
   );
 };
 

--- a/src/pages/MainHome/components/artistCard.jsx
+++ b/src/pages/MainHome/components/artistCard.jsx
@@ -39,6 +39,15 @@ const ButtomWrapper = styled.div`
   margin-bottom: 21px;
 `;
 
+const StyledButton = styled(Button)`
+  background: linear-gradient(
+    92.33deg,
+    rgba(112, 0, 255, 0.8) 6.14%,
+    rgba(193, 92, 255, 0.8) 94.68%
+  );
+  backdrop-filter: blur(4px);
+`;
+
 // 아티스트 이름 component
 const ArtistNameBox = styled.div`
   width: fit-content;
@@ -95,14 +104,14 @@ const ArtistCard = (props) => {
           <ArtistLogoBox iconLink={props.iconLink} />
         </TopWrapper>
         <ButtomWrapper>
-          <Button width="150" height="44">
+          <StyledButton width="150" height="44">
             <Flex>
               <Typography bold16 color="white">
                 앨범함 가기
               </Typography>
               <HiOutlineChevronRight size="20" />
             </Flex>
-          </Button>
+          </StyledButton>
         </ButtomWrapper>
       </CardWrapper>
     </Wrapper>

--- a/src/pages/MainHome/components/cardCarousel.jsx
+++ b/src/pages/MainHome/components/cardCarousel.jsx
@@ -1,0 +1,62 @@
+import React, { Component } from "react";
+import Slider from "react-slick";
+import ArtistCard from "./artistCard";
+import styled from "styled-components";
+import "slick-carousel/slick/slick.css";
+import "slick-carousel/slick/slick-theme.css";
+import "./slick.css";
+
+const CarouselWrapper = styled.div`
+  width: 100%;
+`;
+
+export default class CardCarousel extends Component {
+  render() {
+    const settings = {
+      dots: true,
+      fade: true,
+      infinite: true,
+      speed: 500,
+      slidesToShow: 1,
+      slidesToScroll: 1,
+      arrows: false,
+      appendDots: (dots) => (
+        <div
+          style={{
+            width: "fit-content",
+            marginLeft: "44px",
+            display: "flex",
+            alignItems: "left",
+            justifyContent: "left",
+          }}
+        >
+          <ul> {dots} </ul>
+        </div>
+      ),
+      dotsClass: "dots_custom",
+    };
+
+    return (
+      <CarouselWrapper>
+        <Slider {...settings}>
+          <ArtistCard
+            imgLink="https://img7.yna.co.kr/etc/inner/KR/2019/12/24/AKR20191224038500005_01_i_P4.jpg"
+            iconLink="https://kkukowiki.kr/images/e/e0/%EB%A0%88%EB%93%9C%EB%B2%A8%EB%B2%B3_%EB%A1%9C%EA%B3%A0.png"
+          />
+          <ArtistCard
+            imgLink="https://img7.yna.co.kr/etc/inner/KR/2019/12/24/AKR20191224038500005_01_i_P4.jpg"
+            iconLink="https://kkukowiki.kr/images/e/e0/%EB%A0%88%EB%93%9C%EB%B2%A8%EB%B2%B3_%EB%A1%9C%EA%B3%A0.png"
+          />
+          <ArtistCard
+            imgLink="https://img7.yna.co.kr/etc/inner/KR/2019/12/24/AKR20191224038500005_01_i_P4.jpg"
+            iconLink="https://kkukowiki.kr/images/e/e0/%EB%A0%88%EB%93%9C%EB%B2%A8%EB%B2%B3_%EB%A1%9C%EA%B3%A0.png"
+          />
+          <ArtistCard
+            imgLink="https://img7.yna.co.kr/etc/inner/KR/2019/12/24/AKR20191224038500005_01_i_P4.jpg"
+            iconLink="https://kkukowiki.kr/images/e/e0/%EB%A0%88%EB%93%9C%EB%B2%A8%EB%B2%B3_%EB%A1%9C%EA%B3%A0.png"
+          />
+        </Slider>
+      </CarouselWrapper>
+    );
+  }
+}

--- a/src/pages/MainHome/components/firstAlbum.jsx
+++ b/src/pages/MainHome/components/firstAlbum.jsx
@@ -1,0 +1,80 @@
+import styled, { css } from "styled-components";
+import Typography from "../../../duckku-ui/Typography";
+
+// 앨범 전체 component
+const AlbumWrapper = styled.div`
+  width: 326px;
+  height: 360px;
+  background: #f9f9f9f0;
+  background-size: cover;
+  filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+  border-radius: 20px;
+  overflow: hidden;
+`;
+
+const AlbumImage = styled.div`
+  width: 100%;
+  height: 284px;
+  background: url(${(props) => (props.albumLink ? props.albumLink : "")})
+    no-repeat;
+  background-size: cover;
+`;
+
+const AlbumInfoWrapper = styled.div`
+  width: 100%;
+  height: 76px;
+  padding-left: 27px;
+  display: flex;
+  flex-direction: row;
+  justify-content: left;
+  align-items: center;
+  vertical-align: middle;
+  font-family: "Pretendard-Bold";
+`;
+
+const ArtistLogoBox = styled.div`
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: white url(${(props) => (props.iconLink ? props.iconLink : "")})
+    no-repeat;
+  background-size: 44px;
+  background-position: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+  margin-left: 16px;
+`;
+
+const AlbumInfoTextWrapper = styled.div`
+  width: fit-content;
+  height: 48px;
+  display: flex;
+  flex-direction: column;
+  align-items: left;
+  justify-content: space-between;
+  margin-left: 16px;
+`;
+
+const FirstAlbum = (props) => {
+  return (
+    <AlbumWrapper>
+      <AlbumImage albumLink={props.albumLink} />
+      <AlbumInfoWrapper>
+        <Typography fontSize="28" color="darkGray">
+          1
+        </Typography>
+        <ArtistLogoBox iconLink={props.iconLink} />
+        <AlbumInfoTextWrapper>
+          <Typography bold16>{props.albumName}</Typography>
+          <Typography thin14>
+            {props.artistName} . {props.albumInfo}
+          </Typography>
+        </AlbumInfoTextWrapper>
+      </AlbumInfoWrapper>
+    </AlbumWrapper>
+  );
+};
+
+export default FirstAlbum;

--- a/src/pages/MainHome/components/nthAlbum.jsx
+++ b/src/pages/MainHome/components/nthAlbum.jsx
@@ -1,0 +1,70 @@
+import styled, { css } from "styled-components";
+import Typography from "../../../duckku-ui/Typography";
+
+// 앨범 전체 component
+const AlbumWrapper = styled.div`
+  width: 326px;
+  height: 90px;
+  background: #f9f9f9f0;
+  background-size: cover;
+  filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+  border-radius: 20px;
+`;
+
+const AlbumInfoWrapper = styled.div`
+  width: 100%;
+  height: 90px;
+  padding-left: 27px;
+  display: flex;
+  flex-direction: row;
+  justify-content: left;
+  align-items: center;
+  vertical-align: middle;
+  font-family: "Pretendard-Bold";
+`;
+
+const ArtistLogoBox = styled.div`
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: white url(${(props) => (props.iconLink ? props.iconLink : "")})
+    no-repeat;
+  background-size: 44px;
+  background-position: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+  margin-left: 16px;
+`;
+
+const AlbumInfoTextWrapper = styled.div`
+  width: fit-content;
+  height: 48px;
+  display: flex;
+  flex-direction: column;
+  align-items: left;
+  justify-content: space-between;
+  margin-left: 16px;
+`;
+
+const NthAlbum = (props) => {
+  return (
+    <AlbumWrapper>
+      <AlbumInfoWrapper>
+        <Typography fontSize="28" color="darkGray">
+          {props.rank}
+        </Typography>
+        <ArtistLogoBox iconLink={props.iconLink} />
+        <AlbumInfoTextWrapper>
+          <Typography bold16>{props.albumName}</Typography>
+          <Typography thin14>
+            {props.artistName} . {props.albumInfo}
+          </Typography>
+        </AlbumInfoTextWrapper>
+      </AlbumInfoWrapper>
+    </AlbumWrapper>
+  );
+};
+
+export default NthAlbum;

--- a/src/pages/MainHome/components/slick.css
+++ b/src/pages/MainHome/components/slick.css
@@ -1,0 +1,33 @@
+/* slick.css */
+
+.dots_custom {
+  display: flex;
+  vertical-align: middle;
+  justify-content: space-between;
+  margin: auto 0;
+  padding: 0;
+}
+
+.dots_custom li {
+  list-style: none;
+  cursor: pointer;
+  display: inline-block;
+  margin: 0 4px;
+  padding: 0;
+}
+
+.dots_custom li button {
+  border: none;
+  background: #d9d9d9;
+  color: transparent;
+  cursor: pointer;
+  display: block;
+  height: 10px;
+  width: 10px;
+  border-radius: 100%;
+  padding: 0;
+}
+
+.dots_custom li.slick-active button {
+  background-color: #626262;
+}

--- a/src/pages/MainHome/index.jsx
+++ b/src/pages/MainHome/index.jsx
@@ -4,7 +4,20 @@ import Layout from "../../duckku-ui/Layout";
 import Flex from "../../duckku-ui/Flex";
 import Margin from "../../duckku-ui/Margin";
 import Typography from "../../duckku-ui/Typography";
-import ArtistCard from "./components/artistCard";
+import CardCarousel from "./components/cardCarousel";
+import { HiOutlineChevronDown } from "react-icons/hi";
+import FirstAlbum from "./components/firstAlbum";
+import NthAlbum from "./components/nthAlbum";
+
+// 관심 아티스트와 앨범차트를 따로 감싸기 위한 component
+const PageWrapper = styled.div`
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 0;
+`;
 
 // 상단 Title을 감쌀 component
 const TitleBox = styled.div`
@@ -13,24 +26,118 @@ const TitleBox = styled.div`
   font-family: "Pretendard-Bold";
 `;
 
+// 수정하기 버튼을 감싸는 component (위치 조정용)
+const EditButtonWrapper = styled.div`
+  width: 326px;
+  display: flex;
+  align-items: right;
+  justify-content: right;
+`;
+
+// 관심 아티스트 수정하기 버튼 component
+const EditButton = styled.button`
+  width: fit-content;
+  background: none;
+  border: none;
+  font-family: "Pretendard-Bold";
+  font-size: 16px;
+  font-weight: 700;
+  color: #979797;
+  margin-right: 8px;
+  margin-top: -20px;
+  z-index: 10;
+`;
+
+// 앨범차트 더보기 버튼 component
+const MoreViewButton = styled.button`
+  width: 98px;
+  height: 48px;
+  border: none;
+  background: #f8f8fa;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  border-radius: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+`;
+
+// 앨범 더보기 버튼 내부 Wrapper component
+const MoreViewTextWrapper = styled.div`
+  width: fit-content;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-left: 3px;
+`;
+
 const MainHome = () => {
   return (
     <Layout>
-      <Margin height="37" />
-      <TitleBox>
-        <Flex direction="column" justify="left">
-          <Typography fontSize="28" fontWeight="700">
-            영우 님의
-            <br />
-            관심 아티스트
-          </Typography>
-        </Flex>
-      </TitleBox>
-      <Margin height="40" />
-      <ArtistCard
-        imgLink="https://img7.yna.co.kr/etc/inner/KR/2019/12/24/AKR20191224038500005_01_i_P4.jpg"
-        iconLink="https://kkukowiki.kr/images/e/e0/%EB%A0%88%EB%93%9C%EB%B2%A8%EB%B2%B3_%EB%A1%9C%EA%B3%A0.png"
-      />
+      <PageWrapper>
+        <Margin height="40" />
+        <TitleBox>
+          <Flex direction="column" justify="left">
+            <Typography fontSize="28" fontWeight="700">
+              영우 님의
+              <br />
+              관심 아티스트
+            </Typography>
+          </Flex>
+        </TitleBox>
+        <Margin height="40" />
+        <CardCarousel />
+        <EditButtonWrapper>
+          <EditButton onClick={() => console.log("clicked")}>
+            + 수정하기
+          </EditButton>
+        </EditButtonWrapper>
+      </PageWrapper>
+      <PageWrapper>
+        <Margin height="44" />
+        <TitleBox>
+          <Flex direction="column" justify="left">
+            <Typography fontSize="28" fontWeight="700">
+              앨범차트
+            </Typography>
+          </Flex>
+        </TitleBox>
+        <Margin height="24" />
+        <FirstAlbum
+          albumLink="https://image.genie.co.kr/Y/IMAGE/IMG_ALBUM/082/639/088/82639088_1653623843808_1_600x600.JPG/dims/resize/Q_80,0"
+          iconLink="http://file2.instiz.net/data/cached_img/upload/201507210/88367d0af857e0a6cd53aafbe1c15c49.jpg"
+          albumName="Face The Sun"
+          artistName="Seventeen"
+          albumInfo="정규 4집"
+        />
+        <Margin height="16" />
+        <NthAlbum
+          rank="2"
+          albumLink="https://image.genie.co.kr/Y/IMAGE/IMG_ALBUM/082/639/088/82639088_1653623843808_1_600x600.JPG/dims/resize/Q_80,0"
+          iconLink="http://file2.instiz.net/data/cached_img/upload/201507210/88367d0af857e0a6cd53aafbe1c15c49.jpg"
+          albumName="Face The Sun"
+          artistName="Seventeen"
+          albumInfo="정규 4집"
+        />
+        <Margin height="16" />
+        <NthAlbum
+          rank="3"
+          albumLink="https://image.genie.co.kr/Y/IMAGE/IMG_ALBUM/082/639/088/82639088_1653623843808_1_600x600.JPG/dims/resize/Q_80,0"
+          iconLink="http://file2.instiz.net/data/cached_img/upload/201507210/88367d0af857e0a6cd53aafbe1c15c49.jpg"
+          albumName="Face The Sun"
+          artistName="Seventeen"
+          albumInfo="정규 4집"
+        />
+        <Margin height="16" />
+        <MoreViewButton>
+          <MoreViewTextWrapper>
+            <Typography regular16 color="gray">
+              더보기
+            </Typography>
+            <HiOutlineChevronDown size="22" color="#afafaf" />
+          </MoreViewTextWrapper>
+        </MoreViewButton>
+      </PageWrapper>
       <Footer />
     </Layout>
   );

--- a/src/pages/MainHome/index.jsx
+++ b/src/pages/MainHome/index.jsx
@@ -138,7 +138,7 @@ const MainHome = () => {
           </MoreViewTextWrapper>
         </MoreViewButton>
       </PageWrapper>
-      <Footer />
+      <Footer active="home" />
     </Layout>
   );
 };


### PR DESCRIPTION
### 메인 홈 페이지 작성
- react slick 캐로셀을 install해 사용하였습니다.
- 스크롤 스냅 방식으로 구현하려고 하였으나, 높이가 좁을 때, 가려지는 부분을 따로 확인할 수 없어서 단순 스크롤 방식으로 구현하였습니다.
- 하단 앨범차트 화면에서 더보기 버튼의 경우, 상단 margin을 16px로 수정하였습니다. (디자인 시안은 323px, 디자인팀과 협의 완료)

https://user-images.githubusercontent.com/79556112/184169810-aa0340ab-fca6-4d46-b985-1e9171a866e2.mp4
