### PR TITLE
모바일뷰에서 클릭 시 파란 박스 제거 + 스토어 상단 찜버튼 클릭 영역 수정 + 관심 아티스트 앨범 페이지 수정 + payment 페이지 수

### DIFF
--- a/src/duckku-ui/Album/index.jsx
+++ b/src/duckku-ui/Album/index.jsx
@@ -12,6 +12,7 @@ const Box = styled.div`
   margin-right: 8px;
   margin-bottom: 24px;
   cursor: pointer;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 `;
 
 const ImageContainer = styled.div`

--- a/src/pages/ArtistSelect/components/artistButton.jsx
+++ b/src/pages/ArtistSelect/components/artistButton.jsx
@@ -8,6 +8,7 @@ const ButtonWrapper = styled.button`
   outline: none;
   background: none;
   cursor: pointer;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 `;
 
 const ArtistProfile = styled.div`

--- a/src/pages/ArtistSelect/components/inputBox.jsx
+++ b/src/pages/ArtistSelect/components/inputBox.jsx
@@ -16,6 +16,7 @@ const InputContainer = styled.div`
   background-color: ${(props) =>
     props.backgroundColor ? props.backgroundColor : "#F5F5F5"};
   border-radius: 25px;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 `;
 
 const Input = styled.input`

--- a/src/pages/ArtistSelect/components/optionButton.jsx
+++ b/src/pages/ArtistSelect/components/optionButton.jsx
@@ -23,6 +23,7 @@ const OptionButton = styled.button`
   z-index: 10;
   transition: 0.5s;
   cursor: pointer;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 
   ${(props) =>
     props.activated &&

--- a/src/pages/Interested/index.jsx
+++ b/src/pages/Interested/index.jsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
+import Album from "../../duckku-ui/Album";
 import Header from "../../duckku-ui/Header";
 import Layout from "../../duckku-ui/Layout";
 import Margin from "../../duckku-ui/Margin";
@@ -31,6 +32,66 @@ const IconCenter = styled.div`
 `;
 
 const Interested = () => {
+  const [interestedAlbum, setInterestedAlbum] = useState();
+  const [interestedList, setInterestedList] = useState([
+    {
+      imgLink: "https://image.yes24.com/goods/71935476/XL",
+      albumTitle: "Fancy",
+      artist: "TWICE",
+      year: "2022",
+      isChecked: true,
+    },
+    {
+      imgLink: "https://image.yes24.com/goods/71935476/XL",
+      albumTitle: "Fancy",
+      artist: "TWICE",
+      year: "2022",
+      isChecked: true,
+    },
+    {
+      imgLink: "https://image.yes24.com/goods/71935476/XL",
+      albumTitle: "Fancy",
+      artist: "TWICE",
+      year: "2022",
+      isChecked: false,
+    },
+    {
+      imgLink: "https://image.yes24.com/goods/71935476/XL",
+      albumTitle: "Fancy",
+      artist: "TWICE",
+      year: "2022",
+      isChecked: false,
+    },
+    {
+      imgLink: "https://image.yes24.com/goods/71935476/XL",
+      albumTitle: "Fancy",
+      artist: "TWICE",
+      year: "2022",
+      isChecked: false,
+    },
+    {
+      imgLink: "https://image.yes24.com/goods/71935476/XL",
+      albumTitle: "Fancy",
+      artist: "TWICE",
+      year: "2022",
+      isChecked: false,
+    },
+  ]);
+
+  useEffect(() => {
+    setInterestedAlbum(
+      interestedList.map((album) => (
+        <Album
+          imgLink={album.imgLink}
+          albumTitle={album.albumTitle}
+          artist={album.artist}
+          year={album.year}
+          isChecked={album.isChecked}
+        />
+      ))
+    );
+  }, [interestedList]);
+
   return (
     <Layout>
       <AllInterestedWrapper>
@@ -47,47 +108,8 @@ const Interested = () => {
             </Typography>
           </IconCenter>
         </ViewOrderWrapper>
-        <InterestedCard
-          Img="https://i.pinimg.com/736x/8a/67/57/8a675780020a8172d765b3c0e8b19c26.jpg"
-          SingTitle="More and More"
-          Singer="트와이스"
-          SingYear="2022"
-        />
-
-        <InterestedCard
-          Img="https://upload.wikimedia.org/wikipedia/en/2/20/Iz%2AOne_-_Twelve_A.jpg"
-          SingTitle="More and More"
-          Singer="아이즈원"
-          SingYear="2020"
-        />
-
-        <InterestedCard
-          Img="https://images.genius.com/bfdf3da954dc9937c0e2bac2ea124576.1000x1000x1.png"
-          SingTitle="More and More"
-          Singer="레드벨벳"
-          SingYear="2022"
-        />
-
-        <InterestedCard
-          Img="https://blogger.googleusercontent.com/img/a/AVvXsEgc5SNyrAlpMMg4ovzxpIeYf6bk8uqdWhGLYOeKIpj-lhHXxmOXDrqFCc-RrkpIyGpbqovo3aTZ5jbb_PMOuGzQLcEpO7Nkzn61oSl9xqJLB8bmnrvieq9tD5qO4_LMpecp3r1d_ICjf62eul-cryA9IVYRo-dSN_5TniWYCYePgaDdedOmwrqV62Ix=w640-h568"
-          SingTitle="More and More"
-          Singer="블랙핑크"
-          SingYear="2020"
-        />
-
-        <InterestedCard
-          Img="https://images.genius.com/bfdf3da954dc9937c0e2bac2ea124576.1000x1000x1.png"
-          SingTitle="More and More"
-          Singer="방탄소년단"
-          SingYear="2022"
-        />
-
-        <InterestedCard
-          Img="https://blogger.googleusercontent.com/img/a/AVvXsEgc5SNyrAlpMMg4ovzxpIeYf6bk8uqdWhGLYOeKIpj-lhHXxmOXDrqFCc-RrkpIyGpbqovo3aTZ5jbb_PMOuGzQLcEpO7Nkzn61oSl9xqJLB8bmnrvieq9tD5qO4_LMpecp3r1d_ICjf62eul-cryA9IVYRo-dSN_5TniWYCYePgaDdedOmwrqV62Ix=w640-h568"
-          SingTitle="More and More"
-          Singer="트와이스"
-          SingYear="2022"
-        />
+        <Margin height="16" />
+        {interestedAlbum}
       </AllInterestedWrapper>
     </Layout>
   );

--- a/src/pages/MainHome/components/artistCard.jsx
+++ b/src/pages/MainHome/components/artistCard.jsx
@@ -7,6 +7,8 @@ const Wrapper = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
+  cursor: pointer;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 `;
 
 // 카드 전체 component
@@ -66,8 +68,8 @@ const ArtistNameBox = styled.div`
 
 // 아티스트 로고 component
 const ArtistLogoBox = styled.div`
-  width: 36px;
-  height: 36px;
+  width: 34px;
+  height: 34px;
   margin-top: 16px;
   margin-left: 8px;
   border-radius: 50%;

--- a/src/pages/MainHome/components/firstAlbum.jsx
+++ b/src/pages/MainHome/components/firstAlbum.jsx
@@ -10,6 +10,8 @@ const AlbumWrapper = styled.div`
   filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
   border-radius: 20px;
   overflow: hidden;
+  cursor: pointer;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 `;
 
 const AlbumImage = styled.div`

--- a/src/pages/MainHome/components/nthAlbum.jsx
+++ b/src/pages/MainHome/components/nthAlbum.jsx
@@ -9,6 +9,8 @@ const AlbumWrapper = styled.div`
   background-size: cover;
   filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
   border-radius: 20px;
+  cursor: pointer;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 `;
 
 const AlbumInfoWrapper = styled.div`

--- a/src/pages/MainHome/index.jsx
+++ b/src/pages/MainHome/index.jsx
@@ -44,8 +44,10 @@ const EditButton = styled.button`
   font-weight: 700;
   color: #979797;
   margin-right: 8px;
-  margin-top: -20px;
+  margin-top: -60px;
   z-index: 10;
+  cursor: pointer;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 `;
 
 // 앨범차트 더보기 버튼 component
@@ -60,6 +62,8 @@ const MoreViewButton = styled.button`
   align-items: center;
   justify-content: center;
   vertical-align: middle;
+  cursor: pointer;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 `;
 
 // 앨범 더보기 버튼 내부 Wrapper component

--- a/src/pages/Payment/components/cardCarousel.jsx
+++ b/src/pages/Payment/components/cardCarousel.jsx
@@ -22,6 +22,11 @@ const CardContainer = styled.div`
   align-items: center;
 `;
 
+const CardSvgBox = styled.div`
+  filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+  border-radius: 15px;
+`;
+
 // 카드 내용 작성 랩
 const CardTextWrapper = styled.div`
   width: 262px;
@@ -47,7 +52,9 @@ export default class CardCarousel extends Component {
           <CardContainer>
             <Margin height="61" />
             <Flex justify="center">
-              <RedCard width="262" height="392" />
+              <CardSvgBox>
+                <RedCard width="262" height="392" />
+              </CardSvgBox>
             </Flex>
             <Margin height="29" />
             <Flex justify="center">
@@ -63,7 +70,9 @@ export default class CardCarousel extends Component {
           <CardContainer>
             <Margin height="61" />
             <Flex justify="center">
-              <OrangeCard width="262" height="392" />
+              <CardSvgBox>
+                <OrangeCard width="262" height="392" />
+              </CardSvgBox>
             </Flex>
             <Margin height="29" />
             <Flex justify="center">
@@ -79,7 +88,9 @@ export default class CardCarousel extends Component {
           <CardContainer>
             <Margin height="61" />
             <Flex justify="center">
-              <GreenCard width="262" height="392" />
+              <CardSvgBox>
+                <GreenCard width="262" height="392" />
+              </CardSvgBox>
             </Flex>
             <Margin height="29" />
             <Flex justify="center">
@@ -95,7 +106,9 @@ export default class CardCarousel extends Component {
           <CardContainer>
             <Margin height="61" />
             <Flex justify="center">
-              <BlackCard width="262" height="392" />
+              <CardSvgBox>
+                <BlackCard width="262" height="392" />
+              </CardSvgBox>
             </Flex>
             <Margin height="29" />
             <Flex justify="center">

--- a/src/pages/Store/index.jsx
+++ b/src/pages/Store/index.jsx
@@ -28,6 +28,7 @@ const MoreButton = styled.button`
   padding-left: 8px;
   padding-right: 8px;
   cursor: pointer;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 `;
 
 const FavoriteListWrapper = styled.div`
@@ -57,11 +58,9 @@ const AlbumWrapper = styled.div`
   width: 344px;
 `;
 
-const LikeButton = styled.button`
+const LikeButtonWrapper = styled.div`
   width: 390px;
   height: 70px;
-  background: none;
-  border: none;
   position: fixed;
   top: 0;
   z-index: 20;
@@ -69,7 +68,14 @@ const LikeButton = styled.button`
   justify-content: right;
   align-items: center;
   padding-right: 44px;
+`;
+
+const LikeButton = styled.button`
+  background: none;
+  border: none;
+
   cursor: pointer;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 `;
 
 const Store = () => {
@@ -137,13 +143,15 @@ const Store = () => {
   return (
     <Layout>
       <Header back title="스토어" />
-      <LikeButton onClick={() => setIsLikeClicked(!isLikeClicked)}>
-        {isLikeClicked === false ? (
-          <AiOutlineHeart size="28px" color="#AFAFAF" />
-        ) : (
-          <AiFillHeart size="28px" color={theme.colors.red} />
-        )}
-      </LikeButton>
+      <LikeButtonWrapper>
+        <LikeButton onClick={() => setIsLikeClicked(!isLikeClicked)}>
+          {isLikeClicked === false ? (
+            <AiOutlineHeart size="28px" color="#AFAFAF" />
+          ) : (
+            <AiFillHeart size="28px" color={theme.colors.red} />
+          )}
+        </LikeButton>
+      </LikeButtonWrapper>
       <Margin height="28" />
       <InputBox placeholder="검색어를 입력해 주세요" />
       {isLikeClicked === true ? (


### PR DESCRIPTION
- 모바일 뷰에서 클릭할 수 있는 컴포넌트의 경우, 아래의 코드를 추가하면 모바일에서 파란 박스가 보이지 않도록 수정할 수 있습니다.
```
-webkit-tap-highlight-color : rgba(0,0,0,0);
```
- 스토어 상단 찜버튼 클릭 영역을 수정하였습니다.
- 관심 아티스트 앨범 페이지를 공용 컴포넌트로 교체 + 수정하였습니다.
- payment 페이지 카드에 shadow를 추가하였습니다.